### PR TITLE
Some more themes

### DIFF
--- a/themes/tricolore.css
+++ b/themes/tricolore.css
@@ -26,10 +26,12 @@ pre, code {
 
 pre .comment {
     color: #7E7E7E;
+	font-style: italic;
 }
 
 pre .constant, pre .integer {
     color: #18838A;
+	font-weight: bold;
 }
 
 pre .storage {
@@ -42,6 +44,7 @@ pre .string {
 
 pre .keyword, pre .selector {
     color: #0000A1;
+	font-weight: bold;
 }
 
 pre .parent {


### PR DESCRIPTION
The default theme for Rainbow.js is quite striking and unique, but I'm sure a lot of people—myself included—would like some more choice in themes. I've quickly ported Chocolat's default Tricolore theme across to start with and I'll probably port the two Solarized variants at some point.

Tricolore is a simple, low contrast theme with a light background and looks something like this:

![Tricolore demo](http://f.cl.ly/items/3O2g2f1m2M0I033D1Y3c/Screen%20Shot%202012-03-27%20at%2010.13.20%20AM.png)
