### PR TITLE
javascript: Treat "//" as comment, not constant regex.

### DIFF
--- a/js/language/javascript.js
+++ b/js/language/javascript.js
@@ -53,7 +53,7 @@ Rainbow.extend('javascript', [
             3: 'support.regex.close',
             4: 'support.regex.modifier'
         },
-        'pattern': /(\/)(.*)(\/)([igm]{0,3})/g
+        'pattern': /(\/)(.+)(\/)([igm]{0,3})/g
     },
 
     /**


### PR DESCRIPTION
Well, I'm sure you're sick of me by now :). Here's another one.

In a license header:

```
// Copyright Joyent, Inc. and other Node contributors.
//
// Permission is hereby granted, free of charge, to any person obtaining a
```

The second line was being shown as a constant regex, but should be prettified as comment (`//` is an invalid regex).
