### PR TITLE
ruby: Add regexes, `%Q{}` strings, bug fixes

### DIFF
--- a/demos/ruby-test.html
+++ b/demos/ruby-test.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Ruby Test</title>
+    <link href="../themes/blackboard.css" rel="stylesheet">
+  </head>
+  <body>
+    <pre>
+<code data-language="ruby"># Comments
+not_comment # comment
+
+=begin
+comment
+=end
+
+  =begin
+  not_comment
+  =end
+
+# Strings
+&#39;string&#39;
+&quot;string&quot;
+%q(string)
+%q[string]
+%q{string}
+%q&lt;string&gt;
+%q|string|
+%Q(string)
+%Q[string]
+%Q{string}
+%Q&lt;string&gt;
+%Q|string|
+
+foo(&#39;string&#39;, &#39;string&#39;)
+
+&quot;unsupported\&quot;string&quot;
+
+# Heredocs
+if true
+  DOC = foo(&lt;&lt;-DOC)
+heredoc
+  xxx
+    xxx
+  DOC
+  # ^heredoc ends here
+DOC
+end
+
+if true
+  DOC = foo(&lt;&lt;DOC)
+heredoc
+  xxx
+    xxx
+  DOC
+DOC
+# ^heredoc ends here
+end
+
+# Symbols
+:symbol
+:&#39;long symbol&#39;
+:&quot;long symbol&quot;
+
+# Regular Expressions
+/regex/xxx
+%r(regex)xxx
+%r[regex]xxx
+%r{regex}xxx
+%r&lt;regex&gt;xxx
+%r|regex|xxx
+
+foo(/regex/xxx, /regex/xxx)
+@path.sub(/^#{@root}/, '')
+
+/unsupported\/regex/
+
+# Classes
+class Test &lt; Object
+  attr_accessor :z
+end
+
+x = Test.method(1, 2)
+x = Test::method(1, 2)
+x = Test::CONSTANT
+
+# Methods
+def method(x, y)
+  z = 3
+end
+
+def self.method(x, y)
+  z = 3
+end
+
+# Sigils
+$stderr.puts 3
+@@foo = 3
+@foo = 3
+
+# Data Structures
+[:value]
+[&#39;value&#39;]
+{:key=&gt;&#39;value&#39;}
+{:key =&gt; &#39;value&#39;}
+{&#39;key&#39; =&gt; &#39;value&#39;}
+{key: &#39;value&#39;}
+foo(:key =&gt; &#39;value&#39;)
+foo(key: &#39;value&#39;)
+</code></pre>
+    <script src="../js/rainbow.js"></script>
+    <script src="../js/language/generic.js"></script>
+    <script src="../js/language/ruby.js"></script>
+  </body>
+</html>

--- a/js/language/ruby.js
+++ b/js/language/ruby.js
@@ -6,63 +6,94 @@
  */
 Rainbow.extend('ruby', [
     /**
-     * Strings include heredocs
-     * Heredocs of the form `<<'HTML' ... HTML` are not supported.
-     * Strings of the form `%Q{...}` are not supported.
-     * String interpolation is not supported.
+     * Strings
+     * Escaped quote (`"\""`) is unsupported.
+     * String interpolation is unsupported.
+     */
+    {
+        'name': 'string',
+        'pattern': /(?=['"](.*?)['"])(?:"\1"|'\1')/g
+    },
+    {
+        'name': 'string',
+        'pattern': /%[qQ](?=(\(|\[|\{|&lt;|.)(.*?)(?:'|\)|\]|\}|&gt;|\1))(?:\(\2\)|\[\2\]|\{\2\}|\&lt;\2&gt;|\1\2\1)/g
+    },
+    /**
+     * Heredocs
+     * Heredocs of the form `<<'HTML' ... HTML` are unsupported.
      */
     {
         'matches': {
-            1: {
-                'name': 'keyword.operator',
-                'pattern': /\=/g
-            },
-            2: 'string'
+            1: 'string',
+            2: 'string',
+            3: 'string'
         },
-        'pattern': /(\(|\s|\[|\=|\=&gt;)(&lt;&lt;\-(\S+)[\s\S]*?(\3)|&lt;&lt;(\S+)[\s\S]*?(\5)|('|")[\s\S]*?(\7))/gm
+        'pattern': /(&lt;&lt;)(\w+).*?$([\s\S]*?^\2)/gm
+    },
+    {
+        'matches': {
+            1: 'string',
+            2: 'string',
+            3: 'string'
+        },
+        'pattern': /(&lt;&lt;\-)(\w+).*?$([\s\S]*?\2)/gm
+    },
+    /**
+     * Regular expressions
+     * Escaped delimiter (`/\//`) is unsupported.
+     */
+    {
+        'name': 'constant.regex',
+        'matches': {
+            1: 'support.regex.open',
+            2: {
+                'name': 'constant.regex.escape',
+                'pattern': /\\(.){1}/g
+            },
+            3: 'support.regex.close',
+            4: 'support.regex.modifier'
+        },
+        'pattern': /(\/)(.*?)(\/)([a-z]*)/g,
+    },
+    {
+        'name': 'constant.regex',
+        'matches': {
+            1: 'support.regex.open',
+            2: {
+                'name': 'constant.regex.escape',
+                'pattern': /\\(.){1}/g
+            },
+            3: 'support.regex.close',
+            4: 'support.regex.modifier'
+        },
+        'pattern': /%r(?=(\(|\[|\{|&lt;|.)(.*?)('|\)|\]|\}|&gt;|\1))(?:\(\2\)|\[\2\]|\{\2\}|\&lt;\2&gt;|\1\2\1)([a-z]*)/g
     },
     {
         'name': 'comment',
-        'pattern': /^=begin[\s\S]*?^=end|\#[\s\S]*?$/gm
-    },
-    {
-        'name': 'integer',
-        'pattern': /\b(0x[\da-f]+|\d+)\b/g
-    },
-    {
-        'name': 'variable.global',
-        'pattern': /\$(\w+)\b/g
-    },
-    {
-        'name': 'variable.class',
-        'pattern': /@@(\w+)\b/g
-    },
-    {
-        'name': 'variable.instance',
-        'pattern': /@(\w+)\b/g
-    },
-    {
-        'name': 'constant',
-        'pattern': /\b[A-Z0-9_]{2,}\b/g
+        'pattern': /^=begin[\s\S]*?^=end|\#.*?$/gm
     },
     /**
      * Symbols
      */
     {
         'matches': {
-            1: {
-                'name': 'keyword.operator',
-                'pattern': /\=/g
-            },
-            2: 'constant'
+            1: 'constant'
         },
-        'pattern': /(\(|\s|\[|\=)(:('|")[\s\S]*?(\3)|:\w+)/gm
+        'pattern': /(\w+:)[^:]/g
     },
     {
         'matches': {
-            1: 'keyword'
+            1: 'constant'
         },
-        'pattern': /\b(alias|and|begin|break|case|class|continue|def|defined|do|else|elsif|end|ensure|extend|false|for|if|in|include|module|next|nil|not|or|redo|require|rescue|retry|return|self|super|then|true|undef|unless|until|when|while|yield)(?=\(|\b)/g
+        'pattern': /[^:](:(?:\w+|(?=['"](.*?)['"])(?:"\2"|'\2')))/g
+    },
+    {
+        'name': 'integer',
+        'pattern': /\b(0x[\da-f]+|\d+)\b/g
+    },
+    {
+        'name': 'constant',
+        'pattern': /\b[A-Z0-9_]{2,}\b/g
     },
     {
         'matches': {
@@ -80,10 +111,21 @@ Rainbow.extend('ruby', [
         'pattern': /\b[A-Z]\w*[a-z]\w*\b/g
     },
     {
+        'name': 'variable.global',
+        'pattern': /\$(\w+)\b/g
+    },
+    {
+        'name': 'variable.class',
+        'pattern': /@@(\w+)\b/g
+    },
+    {
+        'name': 'variable.instance',
+        'pattern': /@(\w+)\b/g
+    },
+    {
         'matches': {
-            1: 'keyword',
-            2: 'meta.function'
+            1: 'keyword'
         },
-        'pattern': /(def)\s(.*?)(?=\()/g
+        'pattern': /\b(alias|and|begin|break|case|class|continue|def|defined|do|else|elsif|end|ensure|extend|false|for|if|in|include|module|next|nil|not|private|or|raise|redo|require|rescue|retry|return|self|super|then|true|undef|unless|until|when|while|yield)(?=\(|\b)/g
     }
 ], true);


### PR DESCRIPTION
Hi Craig,

I missed regexes, so here they are now. Also, I rounded up a few corner cases. Let me know if there's anything you want me to change. In particular I wasn't sure if you wanted the unit test. Also, wasn't sure if the "helper function" approach was right.

---

New features:
1. Regexes (`//` and `%r{}` forms)
2. Custom-quoted strings (`%Q{}`, `%q{}`, etc)
3. "unit test" demo: `demos/ruby-test.html`

Bug fixes:
1. Heredocs now start on the next free line. Previously, in `foo(<<EOF)`, the last parens was mistakenly colored as part of the heredoc text.
2. `{` is now allowed to open strings and symbols. Previously, `{:key => 'value'}` and `{'key' => 'value'}` would not color `key` correctly.
