### PR TITLE
Python language patterns won't match multiline docstrings

### DIFF
--- a/demos/python.html
+++ b/demos/python.html
@@ -66,6 +66,9 @@ class WarpWhistle(object):
         self.reset()
 
     def reset(self):
+        """
+        This method resets the properties of the instance.
+        """
         self.current_voices = []
         self.global_vars = {}
         self.vars = {}

--- a/js/language/python.js
+++ b/js/language/python.js
@@ -59,10 +59,9 @@ Rainbow.extend('python', [
     {
         'name': 'meta.decorator',
         'pattern': /@(\w+)/g
-
     },
     {
         'name': 'comment.docstring',
-        'pattern': /""".*"""/g
+        'pattern': /"""[\s\S]*"""/gm
     }
 ]);


### PR DESCRIPTION
This pull request fixes two bugs in the pattern for the Python doctoring:
1. The multiline flag wasn't in place
2. As JavaScript does not implement the dotall flag, the `.` character will never match linebreaks. This uses `[\s\S]` as a working substitute.

Additionally, this adds a test of the docstring pattern in the Python test page.
