### PR TITLE
Integrate @actasflinn's interpolated string regex

### DIFF
--- a/js/language/ruby.js
+++ b/js/language/ruby.js
@@ -3,6 +3,7 @@
  *
  * @author Matthew King
  * @author Jesse Farmer <jesse@20bits.com>
+ * @author actsasflinn
  * @version 1.0.3
  */
 


### PR DESCRIPTION
This integrates @actasflinn's regex for string interpolation in Ruby.

The only change is that it doesn't match for single-quoted strings in Ruby, where interpolation is not allowed.
