### PR TITLE
I've fixed some issues with the c highlighter. 

### DIFF
--- a/demos/c.html
+++ b/demos/c.html
@@ -21,12 +21,12 @@ void floater(int x, int y)
 
 <pre>
 <code data-language="c">
-#include <stdio.h> 
-#include <stdarg.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
+#include &lt;stdio.h&gt;
+#include &lt;stdarg.h&gt;
+#include &lt;sys/types.h&gt;
+#include &lt;sys/stat.h&gt;
+#include &lt;fcntl.h&gt;
+#include &lt;unistd.h&gt;
 
 #ifndef BUF_SIZE
 #define BUF_SIZE 1024

--- a/js/language/c.js
+++ b/js/language/c.js
@@ -77,17 +77,4 @@ Rainbow.extend('c', [
         'pattern': /\b[A-Z0-9_]{2,}\b/g
     },
 
-    /**
-     * this rule is very iffy, but it seems like textmate
-     * highlights anything like this
-     *
-     * using 4 or more characters to avoid keywords intersecting
-     * such as if(  and for(
-     */
-    {
-        'matches': {
-            1: 'support.function.call'
-        },
-        'pattern': /(\w{4,})(?=\()/g
-    }
 ]);


### PR DESCRIPTION
They are:
1) the beginning of variable names like 'charcoal' or 'interval' don't get wrongly marked as types
2) 'die' doesn't get recognized as a keyword
3) I've included the # of #include as part of the span, which seems to accord with most syntax highlighting I've seen.
4) I removed the textmate-inspired emphasis on function calls, which seemed fragile and not-that-desirable anyway. This last one is more of a matter of taste, so I perfectly understand if you don't want to pull that.

I also added some test cases to demos/c.html, particularly to reveal problem #1 above.

This project is great, thanks for developing it---I looked into most of the other js highlighters and liked this one best, particularly for the ease of extensibility and the semantic markup it produces.
