### PR TITLE
Added test for variable variables in PHP

### DIFF
--- a/tests/language/php-test.js
+++ b/tests/language/php-test.js
@@ -22,6 +22,14 @@ RainbowTester.run(
 );
 
 RainbowTester.run(
+    'variable variable',
+
+    '$$foo = true;',
+
+    '<span class="variable dollar-sign">$$</span><span class="variable">foo</span> <span class="keyword operator">=</span> <span class="constant language">true</span>;'
+);
+
+RainbowTester.run(
     'string concatenation',
 
     "$foo = 'test' . 'string' . 'concatenation';",


### PR DESCRIPTION
Test fails. Only the second dollar sign gets wrapped in a span.

http://www.php.net/manual/en/language.variables.variable.php

I thought fixing this would be as simple as adding a plus after the `\$` in the php.js file (line 17), however, that doesn't work. I strips out a dollar sign: `'pattern': /(\$+)(\w+)\b/g`.

This pattern doesn't work neither, it ignores the second dollar sign: `'pattern': /(\$)+(\w+)\b/g`.
