### PR TITLE
Added test for language constants in PHP

### DIFF
--- a/tests/language/php-test.js
+++ b/tests/language/php-test.js
@@ -241,6 +241,14 @@ RainbowTester.run(
 );
 
 RainbowTester.run(
+    'constant language',
+
+    'true; TRUE;',
+
+    '<span class="constant language">true</span>; <span class="constant language">TRUE</span>;'
+);
+
+RainbowTester.run(
     'constant',
 
     'TEST_CONSTANT',


### PR DESCRIPTION
Test fails because only lowercase "true", "false" and "null" are seen as language constants.
