### PR TITLE
Fix for newlines inside <pre> tags on IE8 and below

### DIFF
--- a/js/rainbow.js
+++ b/js/rainbow.js
@@ -624,7 +624,13 @@ window['Rainbow'] = (function() {
                 _addClass(block, 'rainbow');
 
                 return _highlightBlockForLanguage(block.innerHTML, language, function(code) {
-                    block.innerHTML = code;
+                    // fill in the code, the outerHTML/innerHTML logic is a fix for old IEs that break newlines
+                    // see http://www.quirksmode.org/bugreports/archives/2004/11/innerhtml_and_t.html
+                    if ((block.tagName == "CODE" || block.tagName == "PRE") && "outerHTML" in block) {
+                        block.outerHTML = "<" + block.tagName + ">" + code + "</" + block.tagName + ">";
+                    } else {
+                        block.innerHTML = code;
+                    }
 
                     // reset the replacement arrays
                     replacements = {};


### PR DESCRIPTION
On IE8 and below, using `innerHTML` to set code inside a `pre` tag causes whitespace preservation to get hosed (see http://www.quirksmode.org/bugreports/archives/2004/11/innerhtml_and_t.html).

This pull request adds a fix which makes sure newlines still work on older IEs.
