### PR TITLE
Fixed _intersects method.

### DIFF
--- a/js/rainbow.js
+++ b/js/rainbow.js
@@ -184,11 +184,7 @@ window['Rainbow'] = (function() {
      * @returns {boolean}
      */
     function _intersects(start1, end1, start2, end2) {
-        if (start2 >= start1 && start2 < end1) {
-            return true;
-        }
-
-        return end2 > start1 && end2 < end1;
+        return start2 <= end1 && end2 >= start1;
     }
 
     /**


### PR DESCRIPTION
I think that _intersects() is wrongly implemented. Here's a simple suite of tests that show the error and a correct implementation:

    var _intersects = function (start1, end1, start2, end2) {
        if (start2 >= start1 && start2 < end1) {
            return true;
        }

        return end2 > start1 && end2 < end1;
    };

    _intersects = function (start1, end1, start2, end2) {
        return start2 <= end1 && end2 >= start1;
    };

    // disjoint
    console.log(false === _intersects(1, 3, 4, 7));
    // corner case
    console.log(true  === _intersects(1, 4, 4, 7));
    // overlapping
    console.log(true  === _intersects(1, 5, 4, 7));
    // reverse args
    console.log(false === _intersects(4, 7, 1, 3));
    console.log(true  === _intersects(4, 7, 1, 4));
    console.log(true  === _intersects(4, 7, 1, 5));

    // equal
    console.log(true === _intersects(1, 4, 1, 4));
    // inside
    console.log(true === _intersects(1, 4, 2, 3));
    // left end
    console.log(true === _intersects(1, 4, 1, 3));
    // right end
    console.log(true === _intersects(1, 4, 2, 4));
    // reverse args
    console.log(true === _intersects(1, 4, 1, 4));
    console.log(true === _intersects(2, 3, 1, 4));
    console.log(true === _intersects(1, 3, 1, 4));
    console.log(true === _intersects(2, 4, 1, 4));