### PR TITLE
Updated theme to closer match vim Zenburn

### DIFF
--- a/themes/zenburnesque.css
+++ b/themes/zenburnesque.css
@@ -35,11 +35,11 @@ pre .storage {
 
 /* This includes regexes */
 pre .string {
-    color: #FF2020;
+    color: #CC9393;
 }
 
 pre .keyword, pre .selector {
-    color: #ffffa0;
+    color: #FFFFA0;
 }
 
 pre .inherited-class {


### PR DESCRIPTION
This makes the theme closer match the vim version, but crucially makes it much easier to read strings and regexes.
