### PR TITLE
Add basic support for swift language (function definition)

### DIFF
--- a/js/language/swift.js
+++ b/js/language/swift.js
@@ -1,0 +1,15 @@
+/**
+ * Swift patterns
+ *
+ * @author Evgenii Neumerzhitckii
+ * @version 1.0.0
+ */
+Rainbow.extend('swift', [
+    {
+        'matches': {
+            1: 'storage.function',
+            2: 'entity.name.function'
+        },
+        'pattern': /(func)\s(.*?)(?=\()/g
+    }
+]);

--- a/tests/language/test.swift.js
+++ b/tests/language/test.swift.js
@@ -1,0 +1,16 @@
+/* global describe, run */
+var language = 'swift';
+
+describe(language, function() {
+
+    run(
+        language,
+
+        'function definition',
+
+        'func functionName(){}',
+
+        '<span class="storage function">func</span> ' +
+        '<span class="entity name function">functionName</span>(){}'
+    );
+});

--- a/tests/rainbow.html
+++ b/tests/rainbow.html
@@ -28,6 +28,7 @@
     <script src="../js/language/r.js"></script>
     <script src="../js/language/ruby.js"></script>
     <script src="../js/language/smalltalk.js"></script>
+    <script src="../js/language/swift.js"></script>
 
     <script>
         function skip(language, name, code, expected) {
@@ -58,6 +59,7 @@
     <script src="language/test.r.js"></script>
     <script src="language/test.ruby.js"></script>
     <script src="language/test.smalltalk.js"></script>
+    <script src="language/test.swift.js"></script>
 
     <script>
         mocha.globals(['Rainbow']);


### PR DESCRIPTION
Just a start, basic support of Swift language. Highlights the word `func` and function name.

![swift_support_funcion_definition](https://cloud.githubusercontent.com/assets/880411/3712908/46bb1608-153f-11e4-808a-3bd71a1161d4.png)
