### PR TITLE
added Atelier-Schemes color-themes

### DIFF
--- a/themes/atelier-cave-dark.css
+++ b/themes/atelier-cave-dark.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Cave Dark
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #19171c;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #efecf4;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #655f6d;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #be4678; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #aa573c; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #a06e3b; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #2a9292; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #576ddb; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #955ae7; /* purple */
+}

--- a/themes/atelier-cave-light.css
+++ b/themes/atelier-cave-light.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Cave Light
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/cave)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #efecf4;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #19171c;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #7e7887;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #be4678; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #aa573c; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #a06e3b; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #2a9292; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #576ddb; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #955ae7; /* purple */
+}

--- a/themes/atelier-dune-dark.css
+++ b/themes/atelier-dune-dark.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Dune Dark
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #20201d;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #fefbec;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #7d7a68;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #d73737; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #b65611; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #ae9513; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #60ac39; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #6684e1; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #b854d4; /* purple */
+}

--- a/themes/atelier-dune-light.css
+++ b/themes/atelier-dune-light.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Dune Light
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #fefbec;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #20201d;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #999580;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #d73737; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #b65611; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #ae9513; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #60ac39; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #6684e1; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #b854d4; /* purple */
+}

--- a/themes/atelier-estuary-dark.css
+++ b/themes/atelier-estuary-dark.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Estuary Dark
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/estuary)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #22221b;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #f4f3ec;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #6c6b5a;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #ba6236; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #ae7313; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #a5980d; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #7d9726; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #36a166; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #5f9182; /* purple */
+}

--- a/themes/atelier-estuary-light.css
+++ b/themes/atelier-estuary-light.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Estuary Light
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/estuary)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #f4f3ec;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #22221b;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #878573;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #ba6236; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #ae7313; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #a5980d; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #7d9726; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #36a166; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #5f9182; /* purple */
+}

--- a/themes/atelier-forest-dark.css
+++ b/themes/atelier-forest-dark.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Forest Dark
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/forest)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #1b1918;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #f1efee;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #766e6b;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #f22c40; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #df5320; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #c38418; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #7b9726; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #407ee7; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #6666ea; /* purple */
+}

--- a/themes/atelier-forest-light.css
+++ b/themes/atelier-forest-light.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Forest Light
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/forest)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #f1efee;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #1b1918;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #9c9491;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #f22c40; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #df5320; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #c38418; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #7b9726; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #407ee7; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #6666ea; /* purple */
+}

--- a/themes/atelier-heath-dark.css
+++ b/themes/atelier-heath-dark.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Heath Dark
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/heath)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #1b181b;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #f7f3f7;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #776977;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #ca402b; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #a65926; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #bb8a35; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #918b3b; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #516aec; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #7b59c0; /* purple */
+}

--- a/themes/atelier-heath-light.css
+++ b/themes/atelier-heath-light.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Heath Light
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/heath)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #f7f3f7;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #1b181b;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #9e8f9e;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #ca402b; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #a65926; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #bb8a35; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #918b3b; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #516aec; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #7b59c0; /* purple */
+}

--- a/themes/atelier-lakeside-dark.css
+++ b/themes/atelier-lakeside-dark.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Lakeside Dark
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/lakeside/)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #161b1d;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #ebf8ff;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #5a7b8c;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #d22d72; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #935c25; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #8a8a0f; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #568c3b; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #257fad; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #6b6bb8; /* purple */
+}

--- a/themes/atelier-lakeside-light.css
+++ b/themes/atelier-lakeside-light.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Lakeside Light
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/lakeside/)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #ebf8ff;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #161b1d;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #7195a8;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #d22d72; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #935c25; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #8a8a0f; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #568c3b; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #257fad; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #6b6bb8; /* purple */
+}

--- a/themes/atelier-plateau-dark.css
+++ b/themes/atelier-plateau-dark.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Plateau Dark
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/plateau)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #1b1818;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #f4ecec;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #655d5d;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #ca4949; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #b45a3c; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #a06e3b; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #4b8b8b; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #7272ca; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #8464c4; /* purple */
+}

--- a/themes/atelier-plateau-light.css
+++ b/themes/atelier-plateau-light.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Plateau Light
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/plateau)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #f4ecec;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #1b1818;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #7e7777;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #ca4949; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #b45a3c; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #a06e3b; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #4b8b8b; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #7272ca; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #8464c4; /* purple */
+}

--- a/themes/atelier-savanna-dark.css
+++ b/themes/atelier-savanna-dark.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Savanna Dark
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/savanna)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #171c19;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #ecf4ee;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #5f6d64;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #b16139; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #9f713c; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #a07e3b; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #489963; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #478c90; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #55859b; /* purple */
+}

--- a/themes/atelier-savanna-light.css
+++ b/themes/atelier-savanna-light.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Savanna Light
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/savanna)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #ecf4ee;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #171c19;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #78877d;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #b16139; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #9f713c; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #a07e3b; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #489963; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #478c90; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #55859b; /* purple */
+}

--- a/themes/atelier-seaside-dark.css
+++ b/themes/atelier-seaside-dark.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Seaside Dark
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/seaside/)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #131513;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #f4fbf4;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #687d68;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #e6193c; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #87711d; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #98981b; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #29a329; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #3d62f5; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #ad2bee; /* purple */
+}

--- a/themes/atelier-seaside-light.css
+++ b/themes/atelier-seaside-light.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Seaside Light
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/seaside/)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #f4fbf4;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #131513;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #809980;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #e6193c; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #87711d; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #98981b; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #29a329; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #3d62f5; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #ad2bee; /* purple */
+}

--- a/themes/atelier-sulphurpool-dark.css
+++ b/themes/atelier-sulphurpool-dark.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Sulphurpool Dark
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/sulphurpool)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #202746;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #f5f7ff;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #6b7394;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #c94922; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #c76b29; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #c08b30; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #ac9739; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #3d8fd1; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #6679cc; /* purple */
+}

--- a/themes/atelier-sulphurpool-light.css
+++ b/themes/atelier-sulphurpool-light.css
@@ -1,0 +1,49 @@
+/**
+ * Base16 Atelier Sulphurpool Light
+ *
+ * @author Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/sulphurpool)
+ *
+ * Rainbow template by Jan T. Sott (https://github.com/idleberg/)
+ * Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+ */
+pre {
+    background-color: #f5f7ff;
+    word-wrap: break-word;
+    margin: 0px;
+    padding: 10px;
+    color: #202746;
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+pre, code {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', Monaco, 'Courier New', Courier, monospace;
+}
+
+pre .comment {
+    color: #898ea4;
+}
+
+pre .variable.global, pre .variable.class, pre .variable.instance {
+    color: #c94922; /* red */
+}
+
+pre .constant.numeric, pre .constant.language, pre .constant.hex-color, pre .keyword.unit {
+    color: #c76b29; /* orange */
+}
+
+pre .constant, pre .entity, pre .entity.class, pre .support {
+    color: #c08b30; /* yellow */
+}
+
+pre .constant.symbol, pre .string {
+    color: #ac9739; /* green */
+}
+
+pre .entity.function, pre .support.css-property, pre .selector {
+    color: #3d8fd1; /* blue */
+}
+
+pre .keyword, pre .storage {
+    color: #6679cc; /* purple */
+}


### PR DESCRIPTION
Would like to merge for greater discoverability.

> [Atelier Schemes](http://atelierbram.github.io/syntax-highlighting/atelier-schemes/) is a serie of color-schemes that come in a light, and in a dark background version. Generated with Base16-Builder.
