### PR TITLE
PHPDoc comment and Shell command patterns...

### DIFF
--- a/js/language/php.js
+++ b/js/language/php.js
@@ -119,5 +119,28 @@ Rainbow.extend('php', [
             }
         },
         'pattern': /(\(|,\s?)([\w\\]*?)(?=\s\$)/g
+    },
+
+/**
+ * New PHP patterns for:
+ *      PHPDoc comment
+ *      PHPDoc variable
+ *      Shell command
+ *
+ * @author Alexandre Paradis
+ */
+    {
+        'name': 'comment.phpdoc',
+        'matches': {
+            1: {
+                'name': 'keyword.phpdoc',
+                'pattern': /\s+@\w+/g
+            }
+        },
+        'pattern': /\/\*\*([\s\S]*)?\*\//gm
+    },
+    {
+        'name': 'shell.command',
+        'pattern': /`([\s\S]*)?`/gm
     }
 ]);


### PR DESCRIPTION
PHPDoc comments are now identified with classes "comment phpdoc".
Keywords are also identified with classes "keyword phpdoc"

Shell command that uses backticks (ex. `rm -r`) are now identified as "shell command"
![rainbow_phpdoc_shellcmd](https://cloud.githubusercontent.com/assets/12817388/8065146/8ea01eec-0ead-11e5-9921-99d85ef34cd6.png)


***
It is my first pull request, hope everything is fine :)