### PR TITLE
Ruby numbers should support optional underscores

### DIFF
--- a/src/language/ruby.js
+++ b/src/language/ruby.js
@@ -129,7 +129,7 @@ Rainbow.extend('ruby', [
     },
     {
         name: 'constant.numeric',
-        pattern: /\b(0x[\da-f]+|\d+)\b/g
+        pattern: /\b(0x[\da-f]+|[\d_]+)\b/g
     },
     {
         name: 'support.class',

--- a/test/language/ruby-test.js
+++ b/test/language/ruby-test.js
@@ -64,4 +64,14 @@ true
 `
     );
 
+    run(
+        language,
+
+        'numbers with underscores',
+
+        '1_000_000',
+
+        '<span class="constant numeric">1_000_000</span>'
+    );
+
 });


### PR DESCRIPTION
```ruby
# this is a valid integer in Ruby
1_000_000
```