### PR TITLE
Update gulp-git version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gulp-autoprefixer": "3.1.0",
     "gulp-bump": "2.1.0",
     "gulp-eslint": "2.0.0",
-    "gulp-git": "1.7.2",
+    "gulp-git": "2.4.1",
     "gulp-inject-string": "1.1.0",
     "gulp-sass": "2.3.2",
     "karma": "0.13.22",


### PR DESCRIPTION
This makes it possible to build on Node v8 (see stevelacy/gulp-git#164).