### PR TITLE
Change isNode check

### DIFF
--- a/dist/rainbow.js
+++ b/dist/rainbow.js
@@ -5,8 +5,7 @@
 }(this, function () { 'use strict';
 
     function isNode$1() {
-        /* globals module */
-        return typeof module !== 'undefined' && typeof module.exports === 'object';
+        return false;
     }
 
     function isWorker$1() {


### PR DESCRIPTION
The isNode function is problematic, because it no longer works. (Discussed in https://github.com/ccampbell/rainbow/issues/213)

Changing it to return false works for our browser use case, and that's what this diff does.

I could alternatively:
* replace it with a more updated check, although there's a range of opinions about what the best check is (https://stackoverflow.com/questions/4224606/how-to-check-whether-a-script-is-running-under-node-js, look at more recent ones).
* remove the code later that tries to require a file if isNode() is true, and then fails. That's what another person did in the issue about it, and that also works.



