### PR TITLE
Add hash SQL comments

### DIFF
--- a/src/language/sql.js
+++ b/src/language/sql.js
@@ -19,7 +19,7 @@ Rainbow.extend('sql', [
     },
     {
         name: 'comment',
-        pattern: /--.*$|\/\*[\s\S]*?\*\/|(\/\/)[\s\S]*?$/gm
+        pattern: /--.*$|#.*$|\/\*[\s\S]*?\*\/|(\/\/)[\s\S]*?$/gm
     },
     {
         name: 'constant.numeric',

--- a/test/language/sql-test.js
+++ b/test/language/sql-test.js
@@ -54,4 +54,22 @@ export function testSQL(t) {
 
         '<span class="keyword">select</span> <span class="function call">count</span>(<span class="keyword operator">*</span>) <span class="keyword">from</span> some_table <span class="keyword">WHERE</span> some_column <span class="keyword">is</span> <span class="keyword">not</span> <span class="keyword">null</span>;'
     );
+
+    run(
+        t,
+
+        language,
+
+        'comments',
+
+        `/* This
+        is a 
+        multi-line
+        comment */
+        select count(*) -- This is a one type of single line comment
+        from some_table # This is another type of single line comment
+        WHERE some_column is not null;`,
+
+        '<span class="comment">/* This\n        is a \n        multi-line\n        comment */</span>\n        <span class="keyword">select</span> <span class="function call">count</span>(<span class="keyword operator">*</span>) <span class="comment">-- This is a one type of single line comment</span>\n        <span class="keyword">from</span> some_table <span class="comment"># This is another type of single line comment</span>\n        <span class="keyword">WHERE</span> some_column <span class="keyword">is</span> <span class="keyword">not</span> <span class="keyword">null</span>;'
+    );
 }


### PR DESCRIPTION
Some SQL variants (e.g. [mysql](https://dev.mysql.com/doc/refman/8.0/en/comments.html) and [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#single-line-comments)) allow use of a `#` to denote the start of a single-line comment:

```sql
select *   # This is a comment
from table
```

This PR adds that capability to rainbow and also adds some SQL comment tests.